### PR TITLE
Add sushiswap tests

### DIFF
--- a/contracts/exchangeIssuance/ExchangeIssuance.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuance.sol
@@ -270,7 +270,7 @@ contract ExchangeIssuance is ReentrancyGuard {
         
         uint256 initETHAmount = address(_inputToken) == WETH
             ? _maxAmountInputToken
-            :  _swapTokenForWETH(_inputToken, _maxAmountInputToken);
+            : _swapTokenForWETH(_inputToken, _maxAmountInputToken);
         
         uint256 amountEthSpent = _issueExactSetFromWETH(_setToken, _amountSetToken, initETHAmount);
         

--- a/contracts/exchangeIssuance/ExchangeIssuance.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuance.sol
@@ -663,7 +663,7 @@ contract ExchangeIssuance is ReentrancyGuard {
 
             // Get minimum amount of ETH to be spent to acquire the required amount of SetToken component
             uint256 unit = uint256(_setToken.getDefaultPositionRealUnit(_components[i]));
-            amountComponents[i] = uint256(unit).preciseMul(_amountSetToken);
+            amountComponents[i] = uint256(unit).preciseMulCeil(_amountSetToken);
             
             (amountEthIn[i], exchanges[i], pairAddresses[i]) = _getMinTokenForExactToken(amountComponents[i], WETH, _components[i]);
             sumEth = sumEth.add(amountEthIn[i]);

--- a/contracts/exchangeIssuance/ExchangeIssuance.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuance.sol
@@ -462,7 +462,7 @@ contract ExchangeIssuance is ReentrancyGuard {
                 address uniswapPair = _getPair(uniFactory, WETH, components[i]);
                 (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(uniswapPair, WETH, components[i]);
                 amountTokenOut = UniSushiV2Library.getAmountOut(scaledAmountEth, reserveIn, reserveOut);
-            } else if (exchanges[i] == Exchange.Uniswap) {
+            } else if (exchanges[i] == Exchange.Sushiswap) {
                 address sushiswapPair = _getPair(sushiFactory, WETH, components[i]);
                 (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(sushiswapPair, WETH, components[i]);
                 amountTokenOut = UniSushiV2Library.getAmountOut(scaledAmountEth, reserveIn, reserveOut);

--- a/contracts/exchangeIssuance/ExchangeIssuance.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuance.sol
@@ -359,7 +359,7 @@ contract ExchangeIssuance is ReentrancyGuard {
             _redeemExactSet(_setToken, _amountSetToken);
             outputAmount = _liquidateComponentsForWETH(components, amountComponents, exchanges);
         } else {
-            (uint256 totalOutput, Exchange outTokenExchange) = _getMaxTokenForExactToken(totalEth, address(WETH), address(_outputToken));
+            (uint256 totalOutput, Exchange outTokenExchange, ) = _getMaxTokenForExactToken(totalEth, address(WETH), address(_outputToken));
             require(totalOutput > _minOutputReceive, "ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
             _redeemExactSet(_setToken, _amountSetToken);
             uint256 outputEth = _liquidateComponentsForWETH(components, amountComponents, exchanges);
@@ -414,8 +414,7 @@ contract ExchangeIssuance is ReentrancyGuard {
     }
 
     /**
-     * Returns an estimated quantity of the specified SetToken given a specified amount of input ERC20 token.
-     * Estimating pulls the best price of each component using Uniswap or Sushiswap
+     * Returns an estimated amount of SetToken that can be issued given an amount of input ERC20 token.
      *
      * @param _setToken         Address of the SetToken being issued
      * @param _amountInput      Amount of the input token to spend
@@ -438,39 +437,14 @@ contract ExchangeIssuance is ReentrancyGuard {
         uint256 amountEth;
         if (address(_inputToken) != WETH) {
             // get max amount of WETH for the `_amountInput` amount of input tokens
-            (amountEth, ) = _getMaxTokenForExactToken(_amountInput, address(_inputToken), WETH);
+            (amountEth, , ) = _getMaxTokenForExactToken(_amountInput, address(_inputToken), WETH);
         } else {
             amountEth = _amountInput;
         }
         
         address[] memory components = _setToken.getComponents();
-        (
-            uint256 sumEth, 
-            uint256[] memory amountEthIn, 
-            Exchange[] memory exchanges, 
-            uint256[] memory amountComponents
-        ) = _getAmountETHForIssuance(_setToken, components, PreciseUnitMath.preciseUnit());
-        
-        uint256 maxIndexAmount = PreciseUnitMath.maxUint256();
-        
-        for (uint256 i = 0; i < components.length; i++) {
-            uint256 scaledAmountEth = amountEthIn[i].mul(amountEth).div(sumEth);
-            
-            // if exchange[i] is Exchange.None then amountTokenOut remains equal to scaledAmountEth
-            uint256 amountTokenOut = scaledAmountEth;
-            if (exchanges[i] == Exchange.Uniswap) {
-                address uniswapPair = _getPair(uniFactory, WETH, components[i]);
-                (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(uniswapPair, WETH, components[i]);
-                amountTokenOut = UniSushiV2Library.getAmountOut(scaledAmountEth, reserveIn, reserveOut);
-            } else if (exchanges[i] == Exchange.Sushiswap) {
-                address sushiswapPair = _getPair(sushiFactory, WETH, components[i]);
-                (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(sushiswapPair, WETH, components[i]);
-                amountTokenOut = UniSushiV2Library.getAmountOut(scaledAmountEth, reserveIn, reserveOut);
-            }
-            
-            maxIndexAmount = Math.min(amountTokenOut.preciseDiv(amountComponents[i]), maxIndexAmount);
-        }
-        return maxIndexAmount;
+        (uint256 setIssueAmount, , ) = _getSetIssueAmountForETH(_setToken, components, amountEth);
+        return setIssueAmount;
     }
     
     /**
@@ -494,13 +468,13 @@ contract ExchangeIssuance is ReentrancyGuard {
         require(_amountSetToken > 0, "ExchangeIssuance: INVALID INPUTS");
         
         address[] memory components = _setToken.getComponents();
-        (uint256 totalEth, , , ) = _getAmountETHForIssuance(_setToken, components, _amountSetToken);
+        (uint256 totalEth, , , , ) = _getAmountETHForIssuance(_setToken, components, _amountSetToken);
         
         if (address(_inputToken) == WETH) {
             return totalEth;
         }
         
-        (uint256 tokenAmount, ) = _getMinTokenForExactToken(totalEth, address(_inputToken), address(WETH));
+        (uint256 tokenAmount, , ) = _getMinTokenForExactToken(totalEth, address(_inputToken), address(WETH));
         return tokenAmount;
     }
     
@@ -533,7 +507,7 @@ contract ExchangeIssuance is ReentrancyGuard {
         }
         
         // get maximum amount of tokens for totalEth amount of ETH
-        (uint256 tokenAmount, ) = _getMaxTokenForExactToken(totalEth, WETH, _outputToken);
+        (uint256 tokenAmount, , ) = _getMaxTokenForExactToken(totalEth, WETH, _outputToken);
         return tokenAmount;
     }
     
@@ -555,9 +529,7 @@ contract ExchangeIssuance is ReentrancyGuard {
     }
     
     /**
-     * Issues SetTokens for an exact amount of input WETH. 
-     * Acquires SetToken components at the best price accross uniswap and sushiswap.
-     * Uses the acquired components to issue the SetTokens.
+     * Issues SetTokens for an exact amount of input WETH.
      * 
      * @param _setToken         Address of the SetToken being issued
      * @param _minSetReceive    Minimum amount of index to receive
@@ -569,24 +541,19 @@ contract ExchangeIssuance is ReentrancyGuard {
         
         address[] memory components = _setToken.getComponents();
         (
-            uint256 sumEth, 
+            uint256 setIssueAmount, 
             uint256[] memory amountEthIn, 
-            Exchange[] memory exchanges, 
-            uint256[] memory amountComponents
-        ) = _getAmountETHForIssuance(_setToken, components, PreciseUnitMath.preciseUnit());
+            Exchange[] memory exchanges
+        ) = _getSetIssueAmountForETH(_setToken, components, _totalEthAmount);
         
-        // Acquire the SetToken components from exchanges
-        uint256 setTokenAmount = PreciseUnitMath.maxUint256();
+        require(setIssueAmount > _minSetReceive, "ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+        
         for (uint256 i = 0; i < components.length; i++) {
-            uint256 scaledAmountEth = amountEthIn[i].mul(_totalEthAmount).div(sumEth);
-            uint256 amountTokenOut = _swapExactTokensForTokens(exchanges[i], WETH, components[i], scaledAmountEth);
-            setTokenAmount = Math.min(amountTokenOut.preciseDiv(amountComponents[i]), setTokenAmount);
+            _swapExactTokensForTokens(exchanges[i], WETH, components[i], amountEthIn[i]);
         }
         
-        require(setTokenAmount >= _minSetReceive, "ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
-        
-        basicIssuanceModule.issue(_setToken, setTokenAmount, msg.sender);
-        return setTokenAmount;
+        basicIssuanceModule.issue(_setToken, setIssueAmount, msg.sender);
+        return setIssueAmount;
     }
     
     /**
@@ -607,7 +574,7 @@ contract ExchangeIssuance is ReentrancyGuard {
             uint256 sumEth,
             , 
             Exchange[] memory exchanges, 
-            uint256[] memory amountComponents
+            uint256[] memory amountComponents,
         ) = _getAmountETHForIssuance(_setToken, components, _amountSetToken);
         
         require(sumEth <= _maxEther, "ExchangeIssuance: INSUFFICIENT_INPUT_AMOUNT");
@@ -667,16 +634,24 @@ contract ExchangeIssuance is ReentrancyGuard {
      * @return exchanges            An array containing the exchange on which to perform the purchase
      * @return amountComponents     An array containing the amount of each SetToken component required for issuing the given
      *                              amount of SetToken
+     * @return pairAddresses        An array containing the pair addresses of ETH/component exchange pool
      */
     function _getAmountETHForIssuance(ISetToken _setToken, address[] memory _components, uint256 _amountSetToken)
         internal
         view
-        returns (uint256, uint256[] memory, Exchange[] memory, uint256[] memory)
+        returns (
+            uint256 sumEth, 
+            uint256[] memory amountEthIn, 
+            Exchange[] memory exchanges, 
+            uint256[] memory amountComponents, 
+            address[] memory pairAddresses
+        )
     {
-        uint256 sumEth = 0;
-        uint256[] memory amountEthIn = new uint256[](_components.length);
-        uint256[] memory amountComponents = new uint256[](_components.length);
-        Exchange[] memory exchanges = new Exchange[](_components.length);
+        sumEth = 0;
+        amountEthIn = new uint256[](_components.length);
+        amountComponents = new uint256[](_components.length);
+        exchanges = new Exchange[](_components.length);
+        pairAddresses = new address[](_components.length);
         
         for (uint256 i = 0; i < _components.length; i++) {
 
@@ -690,10 +665,10 @@ contract ExchangeIssuance is ReentrancyGuard {
             uint256 unit = uint256(_setToken.getDefaultPositionRealUnit(_components[i]));
             amountComponents[i] = uint256(unit).preciseMul(_amountSetToken);
             
-            (amountEthIn[i], exchanges[i]) = _getMinTokenForExactToken(amountComponents[i], WETH, _components[i]);
+            (amountEthIn[i], exchanges[i], pairAddresses[i]) = _getMinTokenForExactToken(amountComponents[i], WETH, _components[i]);
             sumEth = sumEth.add(amountEthIn[i]);
         }
-        return (sumEth, amountEthIn, exchanges, amountComponents);
+        return (sumEth, amountEthIn, exchanges, amountComponents, pairAddresses);
     }
     
     /**
@@ -730,10 +705,57 @@ contract ExchangeIssuance is ReentrancyGuard {
             amountComponents[i] = unit.preciseMul(_amountSetToken);
             
             // get maximum amount of ETH received for a given amount of SetToken component
-            (amountEth, exchanges[i]) = _getMaxTokenForExactToken(amountComponents[i], _components[i], WETH);
+            (amountEth, exchanges[i], ) = _getMaxTokenForExactToken(amountComponents[i], _components[i], WETH);
             sumEth = sumEth.add(amountEth);
         }
         return (sumEth, amountComponents, exchanges);
+    }
+    
+    /**
+     * Returns an estimated amount of SetToken that can be issued given an amount of input ERC20 token.
+     * 
+     * @param _setToken             Address of the SetToken to be issued
+     * @param _components           An array containing the addresses of the SetToken components
+     * @param _amountEth            Total amount of ether available for the purchase of SetToken components       
+     *
+     * @return setIssueAmount       The max amount of SetTokens that can be issued
+     * @return amountEthIn          An array containing the amount ether required to purchase each SetToken component
+     * @return exchanges            An array containing the exchange on which to purchase the SetToken components
+     */
+    function _getSetIssueAmountForETH(ISetToken _setToken, address[] memory _components, uint256 _amountEth) 
+        internal
+        view
+        returns (uint256 setIssueAmount, uint256[] memory amountEthIn, Exchange[] memory exchanges)
+    {
+        uint256 sumEth;
+        uint256[] memory unitAmountEthIn;
+        uint256[] memory unitAmountComponents;
+        address[] memory pairAddresses;
+        (
+            sumEth,
+            unitAmountEthIn,
+            exchanges, 
+            unitAmountComponents,
+            pairAddresses
+        ) = _getAmountETHForIssuance(_setToken, _components, PreciseUnitMath.preciseUnit());
+        
+        setIssueAmount = PreciseUnitMath.maxUint256();
+        amountEthIn = new uint256[](_components.length);
+        
+        for (uint256 i = 0; i < _components.length; i++) {
+            
+            amountEthIn[i] = unitAmountEthIn[i].mul(_amountEth).div(sumEth);
+            
+            uint256 amountComponent;
+            if (exchanges[i] == Exchange.None) {
+                amountComponent = amountEthIn[i];
+            } else {
+                (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(pairAddresses[i], WETH, _components[i]);
+                amountComponent = UniSushiV2Library.getAmountOut(amountEthIn[i], reserveIn, reserveOut);
+            }
+            setIssueAmount = Math.min(amountComponent.preciseDiv(unitAmountComponents[i]), setIssueAmount);
+        }
+        return (setIssueAmount, amountEthIn, exchanges);
     }
     
     /**
@@ -745,7 +767,7 @@ contract ExchangeIssuance is ReentrancyGuard {
      * @return          Amount of WETH received after the swap
      */
     function _swapTokenForWETH(IERC20 _token, uint256 _amount) internal returns (uint256) {
-        (, Exchange exchange) = _getMaxTokenForExactToken(_amount, address(_token), WETH);
+        (, Exchange exchange, ) = _getMaxTokenForExactToken(_amount, address(_token), WETH);
         IUniswapV2Router02 router = _getRouter(exchange);
         _safeApprove(_token, address(router), _amount);
         return _swapExactTokensForTokens(exchange, address(_token), WETH, _amount);
@@ -801,10 +823,11 @@ contract ExchangeIssuance is ReentrancyGuard {
      *
      * @return              The min amount of tokenA required across both exchanges
      * @return              The Exchange on which minimum amount of tokenA is required
+     * @return              The pair address of the uniswap/sushiswap pool containing _tokenA and _tokenB
      */
-    function _getMinTokenForExactToken(uint256 _amountOut, address _tokenA, address _tokenB) internal view returns (uint256, Exchange) {
+    function _getMinTokenForExactToken(uint256 _amountOut, address _tokenA, address _tokenB) internal view returns (uint256, Exchange, address) {
         if (_tokenA == _tokenB) {
-            return (_amountOut, Exchange.None);
+            return (_amountOut, Exchange.None, ETH_ADDRESS);
         }
         
         uint256 maxIn = PreciseUnitMath.maxUint256() ; 
@@ -831,7 +854,7 @@ contract ExchangeIssuance is ReentrancyGuard {
         
         // Fails if both the values are maxIn
         require(!(uniTokenIn == maxIn && sushiTokenIn == maxIn), "ExchangeIssuance: ILLIQUID_SET_COMPONENT");
-        return (uniTokenIn <= sushiTokenIn) ? (uniTokenIn, Exchange.Uniswap) : (sushiTokenIn, Exchange.Sushiswap);
+        return (uniTokenIn <= sushiTokenIn) ? (uniTokenIn, Exchange.Uniswap, uniswapPair) : (sushiTokenIn, Exchange.Sushiswap, sushiswapPair);
     }
     
     /**
@@ -844,10 +867,11 @@ contract ExchangeIssuance is ReentrancyGuard {
      *
      * @return              The max amount of tokens that can be received across both exchanges
      * @return              The Exchange on which maximum amount of token can be received
+     * @return              The pair address of the uniswap/sushiswap pool containing _tokenA and _tokenB
      */
-    function _getMaxTokenForExactToken(uint256 _amountIn, address _tokenA, address _tokenB) internal view returns (uint256, Exchange) {
+    function _getMaxTokenForExactToken(uint256 _amountIn, address _tokenA, address _tokenB) internal view returns (uint256, Exchange, address) {
         if (_tokenA == _tokenB) {
-            return (_amountIn, Exchange.None);
+            return (_amountIn, Exchange.None, ETH_ADDRESS);
         }
         
         uint256 uniTokenOut = 0;
@@ -867,7 +891,7 @@ contract ExchangeIssuance is ReentrancyGuard {
         
         // Fails if both the values are 0
         require(!(uniTokenOut == 0 && sushiTokenOut == 0), "ExchangeIssuance: ILLIQUID_SET_COMPONENT");
-        return (uniTokenOut >= sushiTokenOut) ? (uniTokenOut, Exchange.Uniswap) : (sushiTokenOut, Exchange.Sushiswap); 
+        return (uniTokenOut >= sushiTokenOut) ? (uniTokenOut, Exchange.Uniswap, uniswapPair) : (sushiTokenOut, Exchange.Sushiswap, sushiswapPair); 
     }
     
     /**

--- a/contracts/exchangeIssuance/ExchangeIssuance.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuance.sol
@@ -812,19 +812,19 @@ contract ExchangeIssuance is ReentrancyGuard {
         uint256 sushiTokenIn = maxIn;
         
         address uniswapPair = _getPair(uniFactory, _tokenA, _tokenB);
-        if(uniswapPair != address(0)) {
+        if (uniswapPair != address(0)) {
             (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(uniswapPair, _tokenA, _tokenB);
             // Prevent subtraction overflow by making sure pool reserves are greater than swap amount
-            if(reserveOut > _amountOut) {
+            if (reserveOut > _amountOut) {
                 uniTokenIn = UniSushiV2Library.getAmountIn(_amountOut, reserveIn, reserveOut);
             }
         }
         
         address sushiswapPair = _getPair(sushiFactory, _tokenA, _tokenB);
-        if(sushiswapPair != address(0)) {
+        if (sushiswapPair != address(0)) {
             (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(sushiswapPair, _tokenA, _tokenB);
             // Prevent subtraction overflow by making sure pool reserves are greater than swap amount
-            if(reserveOut > _amountOut) {
+            if (reserveOut > _amountOut) {
                 sushiTokenIn = UniSushiV2Library.getAmountIn(_amountOut, reserveIn, reserveOut);
             }
         }

--- a/contracts/exchangeIssuance/ExchangeIssuance.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuance.sol
@@ -81,14 +81,14 @@ contract ExchangeIssuance is ReentrancyGuard {
     event ExchangeRedeem(
         address indexed _recipient,     // The recipient address which redeemed the SetTokens
         ISetToken indexed _setToken,    // The redeemed SetToken
-        IERC20 indexed _outputToken,    // The addres of output asset(ERC20/ETH) received by the recipient
+        IERC20 indexed _outputToken,    // The address of output asset(ERC20/ETH) received by the recipient
         uint256 _amountSetRedeemed,     // The amount of SetTokens redeemed for output tokens
         uint256 _amountOutputToken      // The amount of output tokens received by the recipient
     );
 
     event Refund(
         address indexed _recipient,     // The recipient address which redeemed the SetTokens
-        uint256 _refundAmount           // The amount of ETH redunder by this transaction
+        uint256 _refundAmount           // The amount of ETH redunded to the recipient
     );
     
     /* ============ Modifiers ============ */
@@ -541,7 +541,7 @@ contract ExchangeIssuance is ReentrancyGuard {
     /* ============ Internal Functions ============ */
 
     /**
-     * Sets a max aproval limit for an ERC20 token, provided the current allowance 
+     * Sets a max approval limit for an ERC20 token, provided the current allowance 
      * is less than the required allownce. 
      * 
      * @param _token    Token to approve

--- a/contracts/exchangeIssuance/ExchangeIssuance.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuance.sol
@@ -683,7 +683,7 @@ contract ExchangeIssuance is ReentrancyGuard {
             // Check that the component does not have external positions
             require(
                 _setToken.getExternalPositionModules(_components[i]).length == 0,
-                "Exchange Issuance: EXTERNAL_POSITIONS_NOT_ALLOWED"
+                "ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED"
             );
 
             // Get minimum amount of ETH to be spent to acquire the required amount of SetToken component
@@ -723,7 +723,7 @@ contract ExchangeIssuance is ReentrancyGuard {
             // Check that the component does not have external positions
             require(
                 _setToken.getExternalPositionModules(_components[i]).length == 0,
-                "Exchange Issuance: EXTERNAL_POSITIONS_NOT_ALLOWED"
+                "ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED"
             );
             
             uint256 unit = uint256(_setToken.getDefaultPositionRealUnit(_components[i]));

--- a/external/contracts/UniSushiV2Library.sol
+++ b/external/contracts/UniSushiV2Library.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.5.0;
+
+import '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
+
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+
+library UniSushiV2Library {
+    using SafeMath for uint;
+
+    // returns sorted token addresses, used to handle return values from pairs sorted in this order
+    function sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
+        require(tokenA != tokenB, 'UniswapV2Library: IDENTICAL_ADDRESSES');
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        require(token0 != address(0), 'UniswapV2Library: ZERO_ADDRESS');
+    }
+
+    // fetches and sorts the reserves for a pair
+    function getReserves(address pair, address tokenA, address tokenB) internal view returns (uint reserveA, uint reserveB) {
+        (address token0,) = sortTokens(tokenA, tokenB);
+        (uint reserve0, uint reserve1,) = IUniswapV2Pair(pair).getReserves();
+        (reserveA, reserveB) = tokenA == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+    }
+
+    // given some amount of an asset and pair reserves, returns an equivalent amount of the other asset
+    function quote(uint amountA, uint reserveA, uint reserveB) internal pure returns (uint amountB) {
+        require(amountA > 0, 'UniswapV2Library: INSUFFICIENT_AMOUNT');
+        require(reserveA > 0 && reserveB > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+        amountB = amountA.mul(reserveB) / reserveA;
+    }
+
+    // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) internal pure returns (uint amountOut) {
+        require(amountIn > 0, 'UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT');
+        require(reserveIn > 0 && reserveOut > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+        uint amountInWithFee = amountIn.mul(997);
+        uint numerator = amountInWithFee.mul(reserveOut);
+        uint denominator = reserveIn.mul(1000).add(amountInWithFee);
+        amountOut = numerator / denominator;
+    }
+
+    // given an output amount of an asset and pair reserves, returns a required input amount of the other asset
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) internal pure returns (uint amountIn) {
+        require(amountOut > 0, 'UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(reserveIn > 0 && reserveOut > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+        uint numerator = reserveIn.mul(amountOut).mul(1000);
+        uint denominator = reserveOut.sub(amountOut).mul(997);
+        amountIn = (numerator / denominator).add(1);
+    }
+
+    // performs chained getAmountOut calculations on any number of pairs
+    function getAmountsOut(address factory, uint amountIn, address[] memory path) internal view returns (uint[] memory amounts) {
+        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+        amounts = new uint[](path.length);
+        amounts[0] = amountIn;
+        for (uint i; i < path.length - 1; i++) {
+            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i], path[i + 1]);
+            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    // performs chained getAmountIn calculations on any number of pairs
+    function getAmountsIn(address factory, uint amountOut, address[] memory path) internal view returns (uint[] memory amounts) {
+        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+        amounts = new uint[](path.length);
+        amounts[amounts.length - 1] = amountOut;
+        for (uint i = path.length - 1; i > 0; i--) {
+            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i - 1], path[i]);
+            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
+        }
+    }
+}

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import { Address, Account } from "@utils/types";
 import { ADDRESS_ZERO, ZERO, MAX_UINT_256, MAX_UINT_96, MAX_INT_256, ETH_ADDRESS } from "@utils/constants";
-import { ExchangeIssuance, StandardTokenMock, UniswapV2Router02, WETH9 } from "@utils/contracts/index";
+import { ExchangeIssuance, StandardTokenMock, UniswapV2Factory, UniswapV2Router02, WETH9 } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -80,9 +80,9 @@ describe("ExchangeIssuance", async () => {
 
   describe("#constructor", async () => {
     let wethAddress: Address;
-    let uniswapFactory: Address;
+    let uniswapFactory: UniswapV2Factory;
     let uniswapRouter: UniswapV2Router02;
-    let sushiswapFactory: Address;
+    let sushiswapFactory: UniswapV2Factory;
     let sushiswapRouter: UniswapV2Router02;
     let controllerAddress: Address;
     let basicIssuanceModuleAddress: Address;
@@ -103,9 +103,9 @@ describe("ExchangeIssuance", async () => {
       sushiswapSetup = getUniswapFixture(owner.address);
       await sushiswapSetup.initialize(owner, wethAddress, wbtcAddress, daiAddress);
 
-      uniswapFactory = uniswapSetup.factory.address;
+      uniswapFactory = uniswapSetup.factory;
       uniswapRouter = uniswapSetup.router;
-      sushiswapFactory = sushiswapSetup.factory.address;
+      sushiswapFactory = sushiswapSetup.factory;
       sushiswapRouter = sushiswapSetup.router;
       controllerAddress = setV2Setup.controller.address;
       basicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
@@ -114,9 +114,9 @@ describe("ExchangeIssuance", async () => {
     async function subject(): Promise<ExchangeIssuance> {
       return await deployer.adapters.deployExchangeIssuance(
         wethAddress,
-        uniswapFactory,
+        uniswapFactory.address,
         uniswapRouter.address,
-        sushiswapFactory,
+        sushiswapFactory.address,
         sushiswapRouter.address,
         controllerAddress,
         basicIssuanceModuleAddress
@@ -133,13 +133,13 @@ describe("ExchangeIssuance", async () => {
       expect(expectedUniRouterAddress).to.eq(uniswapRouter.address);
 
       const expectedUniFactoryAddress = await exchangeIssuanceContract.uniFactory();
-      expect(expectedUniFactoryAddress).to.eq(uniswapFactory);
+      expect(expectedUniFactoryAddress).to.eq(uniswapFactory.address);
 
       const expectedSushiRouterAddress = await exchangeIssuanceContract.sushiRouter();
       expect(expectedSushiRouterAddress).to.eq(sushiswapRouter.address);
 
       const expectedSushiFactoryAddress = await exchangeIssuanceContract.sushiFactory();
-      expect(expectedSushiFactoryAddress).to.eq(sushiswapFactory);
+      expect(expectedSushiFactoryAddress).to.eq(sushiswapFactory.address);
 
       const expectedControllerAddress = await exchangeIssuanceContract.setController();
       expect(expectedControllerAddress).to.eq(controllerAddress);
@@ -163,9 +163,9 @@ describe("ExchangeIssuance", async () => {
 
   context("when exchange issuance is deployed", async () => {
     let subjectWethAddress: Address;
-    let uniswapFactory: Address;
+    let uniswapFactory: UniswapV2Factory;
     let uniswapRouter: UniswapV2Router02;
-    let sushiswapFactory: Address;
+    let sushiswapFactory: UniswapV2Factory;
     let sushiswapRouter: UniswapV2Router02;
     let controllerAddress: Address;
     let basicIssuanceModuleAddress: Address;
@@ -204,9 +204,9 @@ describe("ExchangeIssuance", async () => {
       await sushiswapSetup.initialize(owner, weth.address, wbtc.address, dai.address);
 
       subjectWethAddress = weth.address;
-      uniswapFactory = uniswapSetup.factory.address;
+      uniswapFactory = uniswapSetup.factory;
       uniswapRouter = uniswapSetup.router;
-      sushiswapFactory = sushiswapSetup.factory.address;
+      sushiswapFactory = sushiswapSetup.factory;
       sushiswapRouter = sushiswapSetup.router;
       controllerAddress = setV2Setup.controller.address;
       basicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
@@ -250,9 +250,9 @@ describe("ExchangeIssuance", async () => {
 
       exchangeIssuance = await deployer.adapters.deployExchangeIssuance(
         subjectWethAddress,
-        uniswapFactory,
+        uniswapFactory.address,
         uniswapRouter.address,
-        sushiswapFactory,
+        sushiswapFactory.address,
         sushiswapRouter.address,
         controllerAddress,
         basicIssuanceModuleAddress

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -920,6 +920,28 @@ describe("ExchangeIssuance", async () => {
             expectedRefund
           );
         });
+
+        context("when exact amount of token needed is supplied", () => {
+          beforeEach(async () => {
+            subjectMaxAmountInput = await getIssueExactSetFromToken(
+              subjectSetToken,
+              subjectInputToken,
+              subjectAmountSetToken,
+              uniswapRouter,
+              uniswapFactory,
+              sushiswapRouter,
+              sushiswapFactory,
+              weth.address
+            );
+          });
+
+          it("should not refund any eth", async () => {
+            await expect(subject()).to.emit(exchangeIssuance, "Refund").withArgs(
+              subjectCaller.address,
+              BigNumber.from(0)
+            );
+          });
+        });
       });
 
       context("when set contains weth", async () => {
@@ -1001,7 +1023,6 @@ describe("ExchangeIssuance", async () => {
           );
         });
       });
-
 
       context("when max input amount is 0", async () => {
         beforeEach(async () => {
@@ -1129,7 +1150,7 @@ describe("ExchangeIssuance", async () => {
         );
       });
 
-      context("when exact amount of token needed is supplied", () => {
+      context("when exact amount of eth needed is supplied", () => {
         beforeEach(async () => {
           subjectAmountETHInput = await getIssueExactSetFromETH(
             subjectSetToken,

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -330,7 +330,7 @@ describe("ExchangeIssuance", async () => {
     });
 
     describe("#approveSetToken", async () => {
-      let subjectSetToApprove: SetToken;
+      let subjectSetToApprove: SetToken | StandardTokenMock;
 
       beforeEach(async () => {
         subjectSetToApprove = setToken;
@@ -353,6 +353,16 @@ describe("ExchangeIssuance", async () => {
           const expectedAllowance = MAX_UINT_96;
           expect(actualAllowance).to.eq(expectedAllowance);
         }
+      });
+
+      context("when the input token is not a set", async () => {
+        beforeEach(async () => {
+          subjectSetToApprove = usdc;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID SET");
+        });
       });
 
       context("when the set contains an external position", async () => {

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -215,8 +215,9 @@ describe("ExchangeIssuance", async () => {
       await uniswapSetup.createNewPair(weth.address, dai.address);
       await uniswapSetup.createNewPair(weth.address, usdc.address);
 
-      await wbtc.approve(sushiswapRouter.address, MAX_UINT_256);
-      await sushiswapRouter.connect(owner.wallet).addLiquidityETH(
+      // ETH-WBTC pools
+      await wbtc.approve(uniswapRouter.address, MAX_UINT_256);
+      await uniswapRouter.connect(owner.wallet).addLiquidityETH(
         wbtc.address,
         UnitsUtils.wbtc(100000),
         MAX_UINT_256,
@@ -226,6 +227,19 @@ describe("ExchangeIssuance", async () => {
         { value: ether(100), gasLimit: 9000000 }
       );
 
+      // cheaper wbtc compared to uniswap
+      await wbtc.approve(sushiswapRouter.address, MAX_UINT_256);
+      await sushiswapRouter.connect(owner.wallet).addLiquidityETH(
+        wbtc.address,
+        UnitsUtils.wbtc(200000),
+        MAX_UINT_256,
+        MAX_UINT_256,
+        owner.address,
+        (await getLastBlockTimestamp()).add(1),
+        { value: ether(100), gasLimit: 9000000 }
+      );
+
+      // ETH-DAI pools
       await dai.approve(uniswapRouter.address, MAX_INT_256);
       await uniswapRouter.connect(owner.wallet).addLiquidityETH(
         dai.address,
@@ -237,6 +251,7 @@ describe("ExchangeIssuance", async () => {
         { value: ether(10), gasLimit: 9000000 }
       );
 
+      // ETH-USDC pools
       await usdc.connect(owner.wallet).approve(uniswapRouter.address, MAX_INT_256);
       await uniswapRouter.connect(owner.wallet).addLiquidityETH(
         usdc.address,
@@ -260,6 +275,7 @@ describe("ExchangeIssuance", async () => {
     });
 
     describe("#approveToken", async () => {
+
       let subjectTokenToApprove: StandardTokenMock;
 
       beforeEach(async () => {

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -211,12 +211,12 @@ describe("ExchangeIssuance", async () => {
       controllerAddress = setV2Setup.controller.address;
       basicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
 
-      await uniswapSetup.createNewPair(weth.address, wbtc.address);
+      await sushiswapSetup.createNewPair(weth.address, wbtc.address);
       await uniswapSetup.createNewPair(weth.address, dai.address);
       await uniswapSetup.createNewPair(weth.address, usdc.address);
 
-      await wbtc.approve(uniswapRouter.address, MAX_UINT_256);
-      await uniswapRouter.connect(owner.wallet).addLiquidityETH(
+      await wbtc.approve(sushiswapRouter.address, MAX_UINT_256);
+      await sushiswapRouter.connect(owner.wallet).addLiquidityETH(
         wbtc.address,
         UnitsUtils.wbtc(100000),
         MAX_UINT_256,
@@ -417,6 +417,9 @@ describe("ExchangeIssuance", async () => {
           subjectInputToken.address,
           subjectAmountInput,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -443,6 +446,9 @@ describe("ExchangeIssuance", async () => {
           subjectInputToken.address,
           subjectAmountInput,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -470,6 +476,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken.address,
             subjectAmountInput,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
 
@@ -496,6 +505,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken.address,
             subjectAmountInput,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
 
@@ -559,6 +571,9 @@ describe("ExchangeIssuance", async () => {
           subjectSetToken,
           subjectAmountETHInput,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           subjectWethAddress
         );
 
@@ -584,6 +599,9 @@ describe("ExchangeIssuance", async () => {
           subjectSetToken,
           subjectAmountETHInput,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           subjectWethAddress
         );
 
@@ -674,6 +692,9 @@ describe("ExchangeIssuance", async () => {
           subjectMaxAmountInput,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -701,6 +722,9 @@ describe("ExchangeIssuance", async () => {
           subjectMaxAmountInput,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -747,6 +771,9 @@ describe("ExchangeIssuance", async () => {
             subjectMaxAmountInput,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
 
@@ -774,6 +801,9 @@ describe("ExchangeIssuance", async () => {
             subjectMaxAmountInput,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
 
@@ -867,6 +897,9 @@ describe("ExchangeIssuance", async () => {
           subjectSetToken,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -882,6 +915,9 @@ describe("ExchangeIssuance", async () => {
           subjectSetToken,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -979,6 +1015,9 @@ describe("ExchangeIssuance", async () => {
           subjectSetToken,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -994,6 +1033,9 @@ describe("ExchangeIssuance", async () => {
           subjectSetToken,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -1078,6 +1120,9 @@ describe("ExchangeIssuance", async () => {
           subjectOutputToken,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -1094,6 +1139,9 @@ describe("ExchangeIssuance", async () => {
           subjectOutputToken,
           subjectAmountSetToken,
           uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
           weth.address
         );
 
@@ -1133,6 +1181,9 @@ describe("ExchangeIssuance", async () => {
             subjectOutputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
 
@@ -1149,6 +1200,9 @@ describe("ExchangeIssuance", async () => {
             subjectOutputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
 
@@ -1215,6 +1269,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken.address,
             subjectAmountInput,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualSetOutput = await subject();
@@ -1234,6 +1291,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken.address,
             subjectAmountInput,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualSetOutput = await subject();
@@ -1253,6 +1313,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken.address,
             subjectAmountInput,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualSetOutput = await subject();
@@ -1301,6 +1364,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualInputAmount = await subject();
@@ -1320,6 +1386,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualInputAmount = await subject();
@@ -1339,6 +1408,9 @@ describe("ExchangeIssuance", async () => {
             subjectInputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualInputAmount = await subject();
@@ -1397,6 +1469,9 @@ describe("ExchangeIssuance", async () => {
             subjectOutputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualOutputAmount = await subject();
@@ -1416,6 +1491,9 @@ describe("ExchangeIssuance", async () => {
             subjectOutputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualOutputAmount = await subject();
@@ -1435,6 +1513,9 @@ describe("ExchangeIssuance", async () => {
             subjectOutputToken,
             subjectAmountSetToken,
             uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
             weth.address
           );
           const actualOutputAmount = await subject();

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -29,6 +29,7 @@ import {
   getRedeemExactSetForETH,
 } from "@utils/common/exchangeIssuanceUtils";
 
+
 const expect = getWaffleExpect();
 
 
@@ -752,8 +753,8 @@ describe("ExchangeIssuance", async () => {
         subjectCaller = user;
         subjectSetToken = setToken;
         subjectInputToken = usdc;
-        subjectMaxAmountInput = UnitsUtils.usdc(1000);
-        subjectAmountSetToken = ether(5);
+        subjectMaxAmountInput = UnitsUtils.usdc(100);
+        subjectAmountSetToken = ether(0.1);
 
         await exchangeIssuance.approveSetToken(subjectSetToken.address, { gasPrice: 0 });
         await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
@@ -998,6 +999,7 @@ describe("ExchangeIssuance", async () => {
         });
       });
 
+
       context("when max input amount is 0", async () => {
         beforeEach(async () => {
           subjectMaxAmountInput = ZERO;
@@ -1122,6 +1124,27 @@ describe("ExchangeIssuance", async () => {
           expectedCost,
           subjectAmountSetToken
         );
+      });
+
+      context("when exact amount of token needed is supplied", () => {
+        beforeEach(async () => {
+          subjectAmountETHInput = await getIssueExactSetFromETH(
+            subjectSetToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+        });
+
+        it("should not refund any eth", async () => {
+          await expect(subject()).to.emit(exchangeIssuance, "Refund").withArgs(
+            subjectCaller.address,
+            BigNumber.from(0)
+          );
+        });
       });
 
       context("when input ether amount is 0", async () => {

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -1201,6 +1201,21 @@ describe("ExchangeIssuance", async () => {
           await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
         });
       });
+
+      context("when there is not enough liquidity to issue required amount (on sushi)", async () => {
+        beforeEach(async () => {
+          subjectSetToken = await setV2Setup.createSetToken(
+            [setV2Setup.wbtc.address],
+            [UnitsUtils.wbtc(1)],
+            [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+          );
+          subjectAmountSetToken = ether(10 ** 10);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
     });
 
     describe("#redeemExactSetForETH", async () => {

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -57,7 +57,7 @@ describe("ExchangeIssuance", async () => {
     setV2Setup = getSetFixture(owner.address);
     await setV2Setup.initialize();
 
-    const daiUnits = ether(0.5);
+    const daiUnits = BigNumber.from("23252699054621733");
     const wbtcUnits = UnitsUtils.wbtc(1);
     setToken = await setV2Setup.createSetToken(
       [setV2Setup.dai.address, setV2Setup.wbtc.address],
@@ -1087,7 +1087,7 @@ describe("ExchangeIssuance", async () => {
       beforeEach(async () => {
         subjectCaller = user;
         subjectSetToken = setToken;
-        subjectAmountSetToken = ether(1000);
+        subjectAmountSetToken = ether(1000.3);
         subjectAmountETHInput = ether(10);
 
         await exchangeIssuance.approveSetToken(setToken.address);
@@ -1248,7 +1248,7 @@ describe("ExchangeIssuance", async () => {
       beforeEach(async () => {
         subjectCaller = user;
         subjectSetToken = setToken;
-        subjectAmountSetToken = ether(100);
+        subjectAmountSetToken = ether(100.3);
         subjectMinEthReceived = ether(0);
 
         await setV2Setup.approveAndIssueSetToken(subjectSetToken, subjectAmountSetToken, subjectCaller.address);

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -1302,6 +1302,16 @@ describe("ExchangeIssuance", async () => {
         });
       });
 
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountInput = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
       context("when set contains weth", async () => {
         beforeEach(async () => {
           subjectSetToken = setTokenWithWeth;
@@ -1397,6 +1407,16 @@ describe("ExchangeIssuance", async () => {
         });
       });
 
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
       context("when set contains weth", async () => {
         beforeEach(async () => {
           subjectSetToken = setTokenWithWeth;
@@ -1448,6 +1468,7 @@ describe("ExchangeIssuance", async () => {
       beforeEach(async () => {
         subjectSetToken = setToken;
         subjectAmountSetToken = ether(100);
+        subjectOutputToken = usdc;
       });
 
       async function subject(): Promise<BigNumber> {
@@ -1457,6 +1478,16 @@ describe("ExchangeIssuance", async () => {
           subjectAmountSetToken
         );
       }
+
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
 
       context("when output is an erc20", async () => {
         beforeEach(async () => {

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import { Address, Account } from "@utils/types";
-import { ADDRESS_ZERO, ZERO, MAX_UINT_256, MAX_UINT_96, MAX_INT_256, ETH_ADDRESS } from "@utils/constants";
+import { ADDRESS_ZERO, ZERO, MAX_UINT_256, MAX_UINT_96, MAX_INT_256, ETH_ADDRESS, ONE } from "@utils/constants";
 import { ExchangeIssuance, StandardTokenMock, UniswapV2Factory, UniswapV2Router02, WETH9 } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
@@ -547,6 +547,16 @@ describe("ExchangeIssuance", async () => {
         });
       });
 
+      context("when required output set token amount is very high", async () => {
+        beforeEach(async () => {
+          subjectMinSetReceive = ether(100000);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+        });
+      });
+
       context("when the set token has an illiquid component", async () => {
         beforeEach(async () => {
           subjectSetToken = setTokenIlliquid;
@@ -637,6 +647,16 @@ describe("ExchangeIssuance", async () => {
 
         it("should revert", async () => {
           await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when required output set token amount is very high", async () => {
+        beforeEach(async () => {
+          subjectMinSetReceive = ether(100000);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
         });
       });
 
@@ -850,6 +870,16 @@ describe("ExchangeIssuance", async () => {
         });
       });
 
+      context("when input token amount is insufficient", async () => {
+        beforeEach(async () => {
+          subjectMaxAmountInput = ONE;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_INPUT_AMOUNT");
+        });
+      });
+
       context("when the set token has an illiquid component", async () => {
         beforeEach(async () => {
           subjectSetToken = setTokenIlliquid;
@@ -963,6 +993,16 @@ describe("ExchangeIssuance", async () => {
 
         it("should revert", async () => {
           await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when input ether amount is insufficient", async () => {
+        beforeEach(async () => {
+          subjectAmountETHInput = ONE;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_INPUT_AMOUNT");
         });
       });
 
@@ -1495,16 +1535,6 @@ describe("ExchangeIssuance", async () => {
         );
       }
 
-      context("when amount Set is 0", async () => {
-        beforeEach(async () => {
-          subjectAmountSetToken = ZERO;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
-        });
-      });
-
       context("when output is an erc20", async () => {
         beforeEach(async () => {
           subjectOutputToken = usdc;
@@ -1568,6 +1598,16 @@ describe("ExchangeIssuance", async () => {
           const actualOutputAmount = await subject();
 
           expect(expectedOutputAmount).to.eq(actualOutputAmount);
+        });
+      });
+
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
         });
       });
 

--- a/utils/common/exchangeIssuanceUtils.ts
+++ b/utils/common/exchangeIssuanceUtils.ts
@@ -102,12 +102,12 @@ export const getIssueExactSetFromToken = async (setToken: SetToken, inputToken: 
     return tokenCost;
 };
 
-export const getIssueExactSetFromTokenRefund = async (setToken: SetToken, inputToken: StandardTokenMock, inputAmount: BigNumber,
+export const getIssueExactSetFromTokenRefund = async (setToken: SetToken, inputToken: StandardTokenMock | WETH9, inputAmount: BigNumber,
     amountSet: BigNumber, uniswapRouter: UniswapV2Router02, uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02,
     sushiswapFactory: UniswapV2Factory, weth: string) => {
 
     const ethCost = await getIssueExactSetFromETH(setToken, amountSet, uniswapRouter, uniswapFactory, sushiswapRouter, sushiswapFactory, weth);
-    const inputEthValue = (await uniswapRouter.getAmountsOut(inputAmount, [inputToken.address, weth]))[1];
+    const inputEthValue = (inputToken.address == weth) ? ethCost : (await uniswapRouter.getAmountsOut(inputAmount, [inputToken.address, weth]))[1];
     const refundAmount = inputEthValue.sub(ethCost);
 
     return refundAmount;

--- a/utils/common/exchangeIssuanceUtils.ts
+++ b/utils/common/exchangeIssuanceUtils.ts
@@ -107,7 +107,9 @@ export const getIssueExactSetFromTokenRefund = async (setToken: SetToken, inputT
     sushiswapFactory: UniswapV2Factory, weth: string) => {
 
     const ethCost = await getIssueExactSetFromETH(setToken, amountSet, uniswapRouter, uniswapFactory, sushiswapRouter, sushiswapFactory, weth);
-    const inputEthValue = (inputToken.address == weth) ? ethCost : (await uniswapRouter.getAmountsOut(inputAmount, [inputToken.address, weth]))[1];
+    const inputEthValue = (inputToken.address == weth)
+        ? inputAmount
+        : (await uniswapRouter.getAmountsOut(inputAmount, [inputToken.address, weth]))[1];
     const refundAmount = inputEthValue.sub(ethCost);
 
     return refundAmount;

--- a/utils/common/exchangeIssuanceUtils.ts
+++ b/utils/common/exchangeIssuanceUtils.ts
@@ -98,7 +98,11 @@ export const getIssueExactSetFromToken = async (setToken: SetToken, inputToken: 
     const ethCost = await getIssueExactSetFromETH(setToken, amountSet, uniswapRouter, uniswapFactory, sushiswapRouter, sushiswapFactory, weth);
     if (inputToken.address === weth) return ethCost;
 
-    const tokenCost = (await uniswapRouter.getAmountsIn(ethCost, [inputToken.address, weth]))[0];
+    const hasUniPair = await hasPair(uniswapFactory, weth, inputToken.address);
+    const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsIn(ethCost, [inputToken.address, weth]))[0] : MAX_UINT_256;
+    const hasSushiPair = await hasPair(sushiswapFactory, weth, inputToken.address);
+    const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsIn(ethCost, [inputToken.address, weth]))[0] : MAX_UINT_256;
+    const tokenCost = (uniAmount.lt(sushiAmount)) ? uniAmount : sushiAmount;
     return tokenCost;
 };
 

--- a/utils/common/exchangeIssuanceUtils.ts
+++ b/utils/common/exchangeIssuanceUtils.ts
@@ -31,12 +31,7 @@ export const getIssueSetForExactETH = async (setToken: SetToken, ethInput: BigNu
             const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsIn(unit, [weth, component]))[0] : MAX_UINT_256;
             const hasSushiPair = await hasPair(sushiswapFactory, weth, component);
             const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsIn(unit, [weth, component]))[0] : MAX_UINT_256;
-
-            if (uniAmount.lt(sushiAmount)) {
-                amountEthForComponent = uniAmount;
-            } else {
-                amountEthForComponent = sushiAmount;
-            }
+            amountEthForComponent = (uniAmount.lt(sushiAmount)) ? uniAmount : sushiAmount;
         }
 
         amountEthForComponents.push(amountEthForComponent);
@@ -57,12 +52,7 @@ export const getIssueSetForExactETH = async (setToken: SetToken, ethInput: BigNu
             const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsOut(scaledEth, [weth, component]))[1] : BigNumber.from(0);
             const hasSushiPair = await hasPair(sushiswapFactory, weth, component);
             const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsOut(scaledEth, [weth, component]))[1] : BigNumber.from(0);
-
-            if (uniAmount.gt(sushiAmount)) {
-                amountComponentOut = uniAmount;
-            } else {
-                amountComponentOut = sushiAmount;
-            }
+            amountComponentOut = (uniAmount.gt(sushiAmount)) ? uniAmount : sushiAmount;
         }
 
         const potentialSetTokenOut = amountComponentOut.mul(ether(1)).div(unit);
@@ -137,12 +127,7 @@ export const getRedeemExactSetForETH = async (setToken: SetToken, amountSet: Big
             const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsOut(componentAmount, [components[i], weth]))[1] : BigNumber.from(0);
             const hasSushiPair = await hasPair(sushiswapFactory, weth, components[i]);
             const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsOut(componentAmount, [components[i], weth]))[1] : BigNumber.from(0);
-
-            if (sushiAmount.gt(uniAmount)) {
-                ethAmount = sushiAmount;
-            } else {
-                ethAmount = uniAmount;
-            }
+            ethAmount = (sushiAmount.gt(uniAmount)) ? sushiAmount : uniAmount;
         } else {
             ethAmount = componentAmount;
         }

--- a/utils/common/exchangeIssuanceUtils.ts
+++ b/utils/common/exchangeIssuanceUtils.ts
@@ -1,8 +1,9 @@
 import { BigNumber } from "ethers";
 import { ether } from "@utils/index";
-import { MAX_UINT_256 } from "@utils/constants";
+import { ADDRESS_ZERO, MAX_UINT_256 } from "@utils/constants";
 import { SetToken } from "@utils/contracts/setV2";
-import { StandardTokenMock, UniswapV2Router02, WETH9 } from "@utils/contracts/index";
+import { StandardTokenMock, UniswapV2Factory, UniswapV2Router02, WETH9 } from "@utils/contracts/index";
+
 
 export const getAllowances = async (tokens: StandardTokenMock[], owner: string, spenders: string[]) => {
     const allowances: BigNumber[] = [];
@@ -12,22 +13,34 @@ export const getAllowances = async (tokens: StandardTokenMock[], owner: string, 
     return allowances;
 };
 
-export const getIssueSetForExactETH = async (setToken: SetToken, ethInput: BigNumber, uniswapRouter: UniswapV2Router02, weth: string) => {
+export const getIssueSetForExactETH = async (setToken: SetToken, ethInput: BigNumber, uniswapRouter: UniswapV2Router02,
+    uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02, sushiswapFactory: UniswapV2Factory, weth: string) => {
+
     let sumEth = BigNumber.from(0);
     const amountEthForComponents = [];
     const components = await setToken.getComponents();
     for (let i = 0; i < components.length; i++) {
         const component = components[i];
         const unit = await setToken.getDefaultPositionRealUnit(component);
+
         let amountEthForComponent = ether(0);
         if (component === weth) {
-            sumEth = sumEth.add(unit);
             amountEthForComponent = unit;
         } else {
-            sumEth = sumEth.add((await uniswapRouter.getAmountsIn(unit, [weth, component]))[0]);
-            amountEthForComponent = (await uniswapRouter.getAmountsIn(unit, [weth, component]))[0];
+            const hasUniPair = await hasPair(uniswapFactory, weth, component);
+            const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsIn(unit, [weth, component]))[0] : MAX_UINT_256;
+            const hasSushiPair = await hasPair(sushiswapFactory, weth, component);
+            const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsIn(unit, [weth, component]))[0] : MAX_UINT_256;
+
+            if (uniAmount.lt(sushiAmount)) {
+                amountEthForComponent = uniAmount;
+            } else {
+                amountEthForComponent = sushiAmount;
+            }
         }
+
         amountEthForComponents.push(amountEthForComponent);
+        sumEth = sumEth.add(amountEthForComponent);
     }
 
     let expectedOutput: BigNumber = MAX_UINT_256;
@@ -36,9 +49,21 @@ export const getIssueSetForExactETH = async (setToken: SetToken, ethInput: BigNu
         const unit = await setToken.getDefaultPositionRealUnit(component);
         const scaledEth = amountEthForComponents[i].mul(ethInput).div(sumEth);
 
-        const amountComponentOut = component === weth
-            ? scaledEth
-            : (await uniswapRouter.getAmountsOut(scaledEth, [weth, component]))[1];
+        let amountComponentOut = BigNumber.from(0);
+        if (component === weth) {
+            amountComponentOut = scaledEth;
+        } else {
+            const hasUniPair = await hasPair(uniswapFactory, weth, component);
+            const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsOut(scaledEth, [weth, component]))[1] : BigNumber.from(0);
+            const hasSushiPair = await hasPair(sushiswapFactory, weth, component);
+            const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsOut(scaledEth, [weth, component]))[1] : BigNumber.from(0);
+
+            if (uniAmount.gt(sushiAmount)) {
+                amountComponentOut = uniAmount;
+            } else {
+                amountComponentOut = sushiAmount;
+            }
+        }
 
         const potentialSetTokenOut = amountComponentOut.mul(ether(1)).div(unit);
         if (potentialSetTokenOut.lt(expectedOutput)) {
@@ -48,31 +73,39 @@ export const getIssueSetForExactETH = async (setToken: SetToken, ethInput: BigNu
     return expectedOutput;
 };
 
-export const getIssueSetForExactToken = async (setToken: SetToken, inputToken: string, inputAmount: BigNumber,
-    uniswapRouter: UniswapV2Router02, weth: string) => {
+export const getIssueSetForExactToken = async (setToken: SetToken, inputToken: string, inputAmount: BigNumber, uniswapRouter: UniswapV2Router02,
+    uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02, sushiswapFactory: UniswapV2Factory, weth: string) => {
 
     // get eth amount that can be aquired with inputToken
     const ethInput = inputToken !== weth ? (await uniswapRouter.getAmountsOut(inputAmount, [inputToken, weth]))[1] : inputAmount;
-    return await getIssueSetForExactETH(setToken, ethInput, uniswapRouter, weth);
+    return await getIssueSetForExactETH(setToken, ethInput, uniswapRouter, uniswapFactory, sushiswapRouter, sushiswapFactory, weth);
 };
 
-export const getIssueExactSetFromETH = async (setToken: SetToken, amountSet: BigNumber, uniswapRouter: UniswapV2Router02, weth: string) => {
+export const getIssueExactSetFromETH = async (setToken: SetToken, amountSet: BigNumber, uniswapRouter: UniswapV2Router02,
+    uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02, sushiswapFactory: UniswapV2Factory, weth: string) => {
     const components = await setToken.getComponents();
     let sumEth = BigNumber.from(0);
     for (let i = 0; i < components.length; i++) {
         const componentAmount = amountSet.mul(await setToken.getDefaultPositionRealUnit(components[i])).div(ether(1));
-        const ethAmount = components[i] === weth
-            ? componentAmount
-            : (await uniswapRouter.getAmountsIn(componentAmount, [weth, components[i]]))[0];
+        const ethAmount = await getInputAmountBestPrice(
+            components[i],
+            componentAmount,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth
+        );
         sumEth = sumEth.add(ethAmount);
     }
     return sumEth;
 };
 
-export const getIssueExactSetFromToken = async (setToken: SetToken, inputToken: StandardTokenMock | WETH9,
-    amountSet: BigNumber, uniswapRouter: UniswapV2Router02, weth: string) => {
+export const getIssueExactSetFromToken = async (setToken: SetToken, inputToken: StandardTokenMock | WETH9, amountSet: BigNumber,
+    uniswapRouter: UniswapV2Router02, uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02,
+    sushiswapFactory: UniswapV2Factory, weth: string) => {
 
-    const ethCost = await getIssueExactSetFromETH(setToken, amountSet, uniswapRouter, weth);
+    const ethCost = await getIssueExactSetFromETH(setToken, amountSet, uniswapRouter, uniswapFactory, sushiswapRouter, sushiswapFactory, weth);
     if (inputToken.address === weth) return ethCost;
 
     const tokenCost = (await uniswapRouter.getAmountsIn(ethCost, [inputToken.address, weth]))[0];
@@ -80,34 +113,73 @@ export const getIssueExactSetFromToken = async (setToken: SetToken, inputToken: 
 };
 
 export const getIssueExactSetFromTokenRefund = async (setToken: SetToken, inputToken: StandardTokenMock, inputAmount: BigNumber,
-    amountSet: BigNumber, uniswapRouter: UniswapV2Router02, weth: string) => {
+    amountSet: BigNumber, uniswapRouter: UniswapV2Router02, uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02,
+    sushiswapFactory: UniswapV2Factory, weth: string) => {
 
-    const ethCost = await getIssueExactSetFromETH(setToken, amountSet, uniswapRouter, weth);
+    const ethCost = await getIssueExactSetFromETH(setToken, amountSet, uniswapRouter, uniswapFactory, sushiswapRouter, sushiswapFactory, weth);
     const inputEthValue = (await uniswapRouter.getAmountsOut(inputAmount, [inputToken.address, weth]))[1];
     const refundAmount = inputEthValue.sub(ethCost);
 
     return refundAmount;
 };
 
-export const getRedeemExactSetForETH = async (setToken: SetToken, amountSet: BigNumber, uniswapRouter: UniswapV2Router02, weth: string) => {
+export const getRedeemExactSetForETH = async (setToken: SetToken, amountSet: BigNumber, uniswapRouter: UniswapV2Router02,
+    uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02, sushiswapFactory: UniswapV2Factory, weth: string) => {
+
     const components = await setToken.getComponents();
     let sumEth = BigNumber.from(0);
     for (let i = 0; i < components.length; i++) {
         const componentAmount = amountSet.mul(await setToken.getDefaultPositionRealUnit(components[i])).div(ether(1));
-        const ethAmount = components[i] === weth
-            ? componentAmount
-            : (await uniswapRouter.getAmountsOut(componentAmount, [components[i], weth]))[1];
+        let ethAmount = BigNumber.from(0);
+
+        if (components[i] !== weth) {
+            const hasUniPair = await hasPair(uniswapFactory, weth, components[i]);
+            const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsOut(componentAmount, [components[i], weth]))[1] : BigNumber.from(0);
+            const hasSushiPair = await hasPair(sushiswapFactory, weth, components[i]);
+            const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsOut(componentAmount, [components[i], weth]))[1] : BigNumber.from(0);
+
+            if (sushiAmount.gt(uniAmount)) {
+                ethAmount = sushiAmount;
+            } else {
+                ethAmount = uniAmount;
+            }
+        } else {
+            ethAmount = componentAmount;
+        }
         sumEth = sumEth.add(ethAmount);
     }
     return sumEth;
 };
 
-export const getRedeemExactSetForToken = async (setToken: SetToken, outputToken: StandardTokenMock | WETH9,
-    amountSet: BigNumber, uniswapRouter: UniswapV2Router02, weth: string) => {
+export const getRedeemExactSetForToken = async (setToken: SetToken, outputToken: StandardTokenMock | WETH9, amountSet: BigNumber,
+    uniswapRouter: UniswapV2Router02, uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02,
+    sushiswapFactory: UniswapV2Factory, weth: string) => {
 
-    const ethOut = await getRedeemExactSetForETH(setToken, amountSet, uniswapRouter, weth);
+    const ethOut = await getRedeemExactSetForETH(setToken, amountSet, uniswapRouter, uniswapFactory, sushiswapRouter, sushiswapFactory, weth);
     if (outputToken.address === weth) return ethOut;
 
     const tokenOut = (await uniswapRouter.getAmountsOut(ethOut, [weth, outputToken.address]))[1];
     return tokenOut;
+};
+
+const hasPair = async (factory: UniswapV2Factory, tokenA: string, tokenB: string) => {
+    return await factory.getPair(tokenA, tokenB) != ADDRESS_ZERO;
+};
+
+const getInputAmountBestPrice = async (token: string, amountIn: BigNumber, uniswapRouter: UniswapV2Router02,
+    uniswapFactory: UniswapV2Factory, sushiswapRouter: UniswapV2Router02, sushiswapFactory: UniswapV2Factory, weth: string) => {
+
+    if (token !== weth) {
+        const hasUniPair = await uniswapFactory.getPair(weth, token) != ADDRESS_ZERO;
+        const uniAmount = hasUniPair ? (await uniswapRouter.getAmountsIn(amountIn, [weth, token]))[0] : MAX_UINT_256;
+        const hasSushiPair = await sushiswapFactory.getPair(weth, token) != ADDRESS_ZERO;
+        const sushiAmount = hasSushiPair ? (await sushiswapRouter.getAmountsIn(amountIn, [weth, token]))[0] : MAX_UINT_256;
+        if (sushiAmount.lt(uniAmount)) {
+            return sushiAmount;
+        } else {
+            return uniAmount;
+        }
+    } else {
+        return amountIn;
+    }
 };


### PR DESCRIPTION
- [x] Add a new library contract `UniSushiV2Library`
- [x] Use new library contract in `ExchangeIssuance`
- [x] Add sushiswap pools in tests, with prices different from uniswap pools
- [x] Modify `@utils/common/exchangeIssuanceUtils` functions to include `sushiswap` pools in the caluclations
- [x] Make sure coverage is 100%